### PR TITLE
Add a config option to run all missing migrations (even those possibly out of order)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+.env
 
 # C extensions
 *.so
@@ -38,3 +39,7 @@ nosetests.xml
 *.db
 
 docs/_*
+
+# IntelliJ Metadata
+*.iml
+*.idea

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Arnold accepts a number of configuration options to the commands.
 
 * --folder - The folder to use for configration/migrations.
 * --fake   - Add the row to the database without running the migration.
+* --migrate-missing - Run every migration that's missing, even if it's out of order. (WARNING: This can lead to data loss in certain situations. See [here](http://arnold.readthedocs.org/en/latest/configuration.html) for more info.)
 
 The `__init__.py` file inside the configuration folder holds the database value. This should be peewee database value. Here is an example `__init__.py` file:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,8 +5,18 @@ Arnold accepts a number of configuration options to the commands.
 
 * --folder - The folder to use for configration/migrations.
 * --fake   - Add the row to the database without running the migration.
+* --migrate-missing - Run every migration that's missing, even if it's out of order.
 
-The `__init__.py` file inside the configuration folder holds the database value. This should be peewee database value. Here is an example `__init__.py` file: ::
+.. warning::
+
+   The ``--migrate-missing`` option can lead to data corruption or loss depending
+   on how you write and name your migrations. If you prefix your migrations with a
+   simple numeric string, there is a possibility they may not be run in the order
+   you expect. If you prefix your migrations with the current date and time, you
+   are much safer. However, if you write non-destructive migrations that don't
+   heavily depend on each other (or at least other, recent ones), you'll be fine.
+
+The `__init__.py` file inside the configuration folder holds the database value. This should be a peewee database value. Here is an example `__init__.py` file: ::
 
   from peewee import SqliteDatabase
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+nose==1.3.7
+peewee==2.8.0
+termcolor==1.1.0

--- a/tests/arnold_config/migrations/003_migrate_missing.py
+++ b/tests/arnold_config/migrations/003_migrate_missing.py
@@ -1,0 +1,19 @@
+from peewee import SqliteDatabase, Model, PrimaryKeyField
+
+from .. import database as db
+
+
+class OutOfOrderMigration(Model):
+    """The migration model used to track migration status"""
+    id = PrimaryKeyField()
+
+    class Meta:
+        database = db
+
+
+def up():
+    OutOfOrderMigration.create_table(fail_silently=True)
+
+
+def down():
+    OutOfOrderMigration.drop_table()

--- a/tests/assets/002_missing_migration.py
+++ b/tests/assets/002_missing_migration.py
@@ -1,0 +1,20 @@
+from peewee import SqliteDatabase, Model, PrimaryKeyField
+
+from .. import database as db
+
+
+class MissingMigration(Model):
+    """The migration model used to track migration status"""
+    id = PrimaryKeyField()
+
+    class Meta:
+        database = db
+
+
+def up():
+    MissingMigration.create_table(fail_silently=True)
+
+
+def down():
+    MissingMigration.drop_table()
+

--- a/tests/assets/004_ensure_ordering_migration.py
+++ b/tests/assets/004_ensure_ordering_migration.py
@@ -1,0 +1,20 @@
+from peewee import SqliteDatabase, Model, PrimaryKeyField
+
+from .. import database as db
+
+
+class OutOfOrderMigration(Model):
+    """The migration model used to track migration status"""
+    id = PrimaryKeyField()
+
+    class Meta:
+        database = db
+
+
+def up():
+    OutOfOrderMigration.insert().execute()
+
+
+def down():
+    OutOfOrderMigration.delete().execute()
+


### PR DESCRIPTION
This PR adds support for a new command line option to `arnold up` named `--migrate-missing`. `--migrate-missing` changes the behavior of arnold to run **all** migrations that have not been run, even those that might be out of order.

Consider this file structure:

```
.
├── 001_mig.py
├── 003_mig.py
└── 004_mig.py
```

4 migrations that have all been migrated up. Then a branch is merged in with a migration named: `002_mig.py`. Creating:

```
.
├── 001_mig.py
├── 002_mig.py
├── 003_mig.py
└── 004_mig.py
```

With the current way arnold works, this new migration will not be picked up at all and will be skipped. This is because arnold always starts at the latest migration and migrates from there.

The `--migrate-missing` flag fixes this and runs the missing migrations. I know this can be dangerous, but it's part of my team's workflow and, if you name your migrations via date, keep them non-destructive and don't have them heavily depend on each other, it really isn't that dangerous (we've had zero issues in the 3 years we've done this).

Since it's dangerous, it's an opt-in command line flag.

It also adds full tests for it,  some docs, and a `requirements.txt` to run the tests, plus a few `.gitignore` updates. Let me know if any of that is an issue!